### PR TITLE
Update branding references to Sykors

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,5 @@
 # Learn about the various environment variables at
-# https://www.chatwoot.com/docs/self-hosted/configuration/environment-variables/#rails-production-variables
+# https://sykors.media/docs/self-hosted/configuration/environment-variables/#rails-production-variables
 
 # Used to verify the integrity of signed cookies. so ensure a secure value is set
 # SECRET_KEY_BASE should be alphanumeric. Avoid special characters or symbols.
@@ -66,10 +66,10 @@ RAILS_MAX_THREADS=5
 
 # The email from which all outgoing emails are sent
 # could user either  `email@yourdomain.com` or `BrandName <email@yourdomain.com>`
-MAILER_SENDER_EMAIL=Chatwoot <accounts@chatwoot.com>
+MAILER_SENDER_EMAIL=Sykors <accounts@sykors.media>
 
 #SMTP domain key is set up for HELO checking
-SMTP_DOMAIN=chatwoot.com
+SMTP_DOMAIN=sykors.media
 # Set the value to "mailhog" if using docker-compose for development environments,
 # Set the value as "localhost" or your SMTP address in other environments
 # If SMTP_ADDRESS is empty, Chatwoot would try to use sendmail(postfix)
@@ -119,7 +119,7 @@ MANDRILL_INGRESS_API_KEY=
 ACTIVE_STORAGE_SERVICE=local
 
 # Amazon S3
-# documentation: https://www.chatwoot.com/docs/configuring-s3-bucket-as-cloud-storage
+# documentation: https://sykors.media/docs/configuring-s3-bucket-as-cloud-storage
 S3_BUCKET_NAME=
 AWS_ACCESS_KEY_ID=
 AWS_SECRET_ACCESS_KEY=
@@ -136,7 +136,7 @@ LOG_SIZE=500
 ### This environment variables are only required if you are setting up social media channels
 
 # Facebook
-# documentation: https://www.chatwoot.com/docs/facebook-setup
+# documentation: https://sykors.media/docs/facebook-setup
 FB_VERIFY_TOKEN=
 FB_APP_SECRET=
 FB_APP_ID=
@@ -145,7 +145,7 @@ FB_APP_ID=
 IG_VERIFY_TOKEN=
 
 # Twitter
-# documentation: https://www.chatwoot.com/docs/twitter-app-setup
+# documentation: https://sykors.media/docs/twitter-app-setup
 TWITTER_APP_ID=
 TWITTER_CONSUMER_KEY=
 TWITTER_CONSUMER_SECRET=

--- a/app/controllers/public_controller.rb
+++ b/app/controllers/public_controller.rb
@@ -15,7 +15,7 @@ class PublicController < ActionController::Base
 
     render json: {
       error: "Domain: #{domain} is not registered with us. \
-      Please send us an email at support@chatwoot.com with the custom domain name and account API key"
+      Please send us an email at support@sykors.media with the custom domain name and account API key"
     }, status: :unauthorized and return
   end
 end

--- a/app/javascript/dashboard/i18n/locale/en/inboxMgmt.json
+++ b/app/javascript/dashboard/i18n/locale/en/inboxMgmt.json
@@ -770,7 +770,7 @@
         "USER_MESSAGE": "Hi",
         "AGENT_MESSAGE": "Hello"
       },
-      "BRANDING_TEXT": "Powered by Chatwoot",
+      "BRANDING_TEXT": "Powered by Sykors",
       "SCRIPT_SETTINGS": "\n      window.chatwootSettings = {options};"
     },
     "EMAIL_PROVIDERS": {

--- a/app/javascript/dashboard/i18n/locale/en/signup.json
+++ b/app/javascript/dashboard/i18n/locale/en/signup.json
@@ -4,7 +4,7 @@
     "TITLE": "Register",
     "TESTIMONIAL_HEADER": "All it takes is one step to move forward",
     "TESTIMONIAL_CONTENT": "You're one step away from engaging your customers, retaining them and finding new ones.",
-    "TERMS_ACCEPT": "By creating an account, you agree to our <a href=\"https://www.chatwoot.com/terms\">T & C</a> and <a href=\"https://www.chatwoot.com/privacy-policy\">Privacy policy</a>",
+    "TERMS_ACCEPT": "By creating an account, you agree to our <a href=\"https://sykors.media/terms\">T & C</a> and <a href=\"https://sykors.media/privacy-policy\">Privacy policy</a>",
     "OAUTH": {
       "GOOGLE_SIGNUP": "Sign up with Google"
     },

--- a/app/javascript/survey/i18n/locale/en.json
+++ b/app/javascript/survey/i18n/locale/en.json
@@ -15,5 +15,5 @@
       "ERROR_MESSAGE": "Could not connect to Woot Server, Please try again later"
     }
   },
-  "POWERED_BY": "Powered by Chatwoot"
+  "POWERED_BY": "Powered by Sykors"
 }

--- a/app/javascript/widget/i18n/locale/en.json
+++ b/app/javascript/widget/i18n/locale/en.json
@@ -46,7 +46,7 @@
   "BUBBLE": {
     "LABEL": "Chat with us"
   },
-  "POWERED_BY": "Powered by Chatwoot",
+  "POWERED_BY": "Powered by Sykors",
   "EMAIL_PLACEHOLDER": "Please enter your email",
   "CHAT_PLACEHOLDER": "Type your message",
   "TODAY": "Today",

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,7 +1,7 @@
 class ApplicationMailer < ActionMailer::Base
   include ActionView::Helpers::SanitizeHelper
 
-  default from: ENV.fetch('MAILER_SENDER_EMAIL', 'Chatwoot <accounts@chatwoot.com>')
+  default from: ENV.fetch('MAILER_SENDER_EMAIL', 'Sykors <accounts@sykors.media>')
   before_action { ensure_current_account(params.try(:[], :account)) }
   around_action :switch_locale
   layout 'mailer/base'

--- a/app/mailers/conversation_reply_mailer.rb
+++ b/app/mailers/conversation_reply_mailer.rb
@@ -4,7 +4,7 @@ class ConversationReplyMailer < ApplicationMailer
   attr_reader :large_attachments
 
   include ConversationReplyMailerHelper
-  default from: ENV.fetch('MAILER_SENDER_EMAIL', 'Chatwoot <accounts@chatwoot.com>')
+  default from: ENV.fetch('MAILER_SENDER_EMAIL', 'Sykors <accounts@sykors.media>')
   layout :choose_layout
 
   def reply_with_summary(conversation, last_queued_id)

--- a/app/presenters/mail_presenter.rb
+++ b/app/presenters/mail_presenter.rb
@@ -152,7 +152,7 @@ class MailPresenter < SimpleDelegator
 
   def notification_email_from_chatwoot?
     # notification emails are send via mailer sender email address. so it should match
-    original_sender == Mail::Address.new(ENV.fetch('MAILER_SENDER_EMAIL', 'Chatwoot <accounts@chatwoot.com>')).address
+    original_sender == Mail::Address.new(ENV.fetch('MAILER_SENDER_EMAIL', 'Sykors <accounts@sykors.media>')).address
   end
 
   private

--- a/app/views/super_admin/settings/show.html.erb
+++ b/app/views/super_admin/settings/show.html.erb
@@ -17,7 +17,7 @@
     <div class="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded relative mb-5" role="alert">
     <strong class="font-bold">Alert!</strong>
     <span class="block sm:inline">Unauthorized premium changes detected in Chatwoot. To keep using them, please upgrade your plan.
-      Contact for help :</span><span class="inline rounded-full bg-red-200 px-2  text-white  ml-2">sales@chatwoot.com</span>
+      Contact for help :</span><span class="inline rounded-full bg-red-200 px-2  text-white  ml-2">sales@sykors.media</span>
     </div>
   <% end %>
 

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -12,7 +12,7 @@ Devise.setup do |config|
   # Configure the e-mail address which will be shown in Devise::Mailer,
   # note that it will be overwritten if you use your own mailer class
   # with default "from" parameter.
-  config.mailer_sender = ENV.fetch('MAILER_SENDER_EMAIL', 'Chatwoot <accounts@chatwoot.com>')
+  config.mailer_sender = ENV.fetch('MAILER_SENDER_EMAIL', 'Sykors <accounts@sykors.media>')
 
   # Configure the class responsible to send e-mails.
   # config.mailer = 'Devise::Mailer'

--- a/config/installation_config.yml
+++ b/config/installation_config.yml
@@ -30,23 +30,23 @@
   display_title: 'Logo Dark Mode'
   description: 'The logo that would be used on the dashboard, login page etc. for dark mode'
 - name: BRAND_URL
-  value: 'https://www.chatwoot.com'
+  value: 'https://sykors.media'
   display_title: 'Brand URL'
   description: 'The URL that would be used in emails under the section “Powered By”'
 - name: WIDGET_BRAND_URL
-  value: 'https://www.chatwoot.com'
+  value: 'https://sykors.media'
   display_title: 'Widget Brand URL'
   description: 'The URL that would be used in the widget under the section “Powered By”'
 - name: BRAND_NAME
-  value: 'Chatwoot'
+  value: 'Sykors'
   display_title: 'Brand Name'
   description: 'The name that would be used in emails and the widget'
 - name: TERMS_URL
-  value: 'https://www.chatwoot.com/terms-of-service'
+  value: 'https://sykors.media/terms-of-service'
   display_title: 'Terms URL'
   description: 'The terms of service URL displayed in Signup Page'
 - name: PRIVACY_URL
-  value: 'https://www.chatwoot.com/privacy-policy'
+  value: 'https://sykors.media/privacy-policy'
   display_title: 'Privacy URL'
   description: 'The privacy policy URL displayed in the app'
 - name: DISPLAY_MANIFEST

--- a/enterprise/config/premium_installation_config.yml
+++ b/enterprise/config/premium_installation_config.yml
@@ -8,15 +8,15 @@
 - name: LOGO_DARK
   value: '/brand-assets/logo_dark.svg'
 - name: BRAND_URL
-  value: 'https://www.chatwoot.com'
+  value: 'https://sykors.media'
 - name: WIDGET_BRAND_URL
-  value: 'https://www.chatwoot.com'
+  value: 'https://sykors.media'
 - name: BRAND_NAME
-  value: 'Chatwoot'
+  value: 'Sykors'
 - name: TERMS_URL
-  value: 'https://www.chatwoot.com/terms-of-service'
+  value: 'https://sykors.media/terms-of-service'
 - name: PRIVACY_URL
-  value: 'https://www.chatwoot.com/privacy-policy'
+  value: 'https://sykors.media/privacy-policy'
 - name: DISPLAY_MANIFEST
   value: true
 # ------- End of Branding Related Config ------- #


### PR DESCRIPTION
## Summary
- update Powered by messages for widget, dashboard and survey
- point signup links to sykors.media
- switch default mail sender to Sykors
- update public controller and admin contact info
- change default branding config values
- update env example values

## Testing
- `bundle exec rubocop -A` *(fails: command not found)*
- `pnpm eslint` *(fails: fetch failed because internet access is disabled)*

------
https://chatgpt.com/codex/tasks/task_e_68596d4b87c8832e9001cac8d5f316f5